### PR TITLE
feat: add static verify_proof function to MerkleTree

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,3 +41,12 @@ jobs:
       - uses: actions/checkout@v4
       - name: Run merkle_proof_check tests
         run: cargo test merkle_proof_check
+
+  verify_proof:
+    needs: ["build_merkletreers_library"]
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run verify_proof tests
+        run: cargo test verify_proof

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "merkletreers"
-version = "1.2.0"
+version = "1.3.0"
 edition = "2021"
 description = "🌳 The simple and easy implementation of Merkle Tree"
 authors = ["Lucas Oliveira <olivmath@protonmail.com>"]

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -19,6 +19,31 @@ impl MerkleTree<Keccak256Hasher> {
     pub fn new(leaves: Vec<Leaf>) -> Self {
         Self::new_with_hasher(leaves, Keccak256Hasher)
     }
+
+    /// Verify a Merkle proof without needing a tree instance
+    ///
+    /// # Arguments
+    /// * `proof` - The Merkle proof to verify
+    /// * `leaf` - The leaf to verify
+    /// * `root` - The expected root hash
+    ///
+    /// # Returns
+    /// `true` if the proof is valid, `false` otherwise
+    ///
+    /// # Example
+    /// ```
+    /// use merkletreers::tree::MerkleTree;
+    /// use merkletreers::node::{Node, Side};
+    ///
+    /// let leaf = [0u8; 32];
+    /// let root = [0u8; 32];
+    /// let proof = vec![Node { data: [0u8; 32], side: Side::LEFT }];
+    ///
+    /// let is_valid = MerkleTree::verify_proof(proof, leaf, root);
+    /// ```
+    pub fn verify_proof(proof: Proof, leaf: Leaf, root: Root) -> bool {
+        Self::verify_proof_with_hasher(proof, leaf, root, &Keccak256Hasher)
+    }
 }
 
 impl<H: Hashable> MerkleTree<H> {
@@ -38,5 +63,20 @@ impl<H: Hashable> MerkleTree<H> {
 
     pub fn check_proof(&self, proof: Proof, leaf: Leaf) -> Leaf {
         merkle_proof_check(proof, leaf, &self.hasher)
+    }
+
+    /// Verify a Merkle proof with a custom hasher without needing a tree instance
+    ///
+    /// # Arguments
+    /// * `proof` - The Merkle proof to verify
+    /// * `leaf` - The leaf to verify
+    /// * `root` - The expected root hash
+    /// * `hasher` - The hasher to use for verification
+    ///
+    /// # Returns
+    /// `true` if the proof is valid, `false` otherwise
+    pub fn verify_proof_with_hasher(proof: Proof, leaf: Leaf, root: Root, hasher: &H) -> bool {
+        let computed_root = merkle_proof_check(proof, leaf, hasher);
+        computed_root == root
     }
 }

--- a/tests/test_merkle_proof_check.rs
+++ b/tests/test_merkle_proof_check.rs
@@ -1,6 +1,7 @@
 use merkletreers::hasher::Keccak256Hasher;
 use merkletreers::merkle_proof_check::merkle_proof_check;
 use merkletreers::node::{Node, Side};
+use merkletreers::tree::MerkleTree;
 use merkletreers::{Leaf, Root};
 
 #[cfg(test)]
@@ -125,6 +126,72 @@ mod tests {
             let result = merkle_proof_check(SETUP_PROOF.to_vec(), SETUP_LEAF, &Keccak256Hasher);
 
             assert_eq!(result, SETUP_ROOT);
+        }
+    }
+
+    mod verify_proof_static {
+        use super::*;
+
+        const SETUP_ROOT: Root = [
+            144, 18, 241, 225, 138, 135, 121, 13, 46, 1, 250, 172, 231, 90, 170, 202, 56, 229, 61,
+            244, 55, 205, 206, 44, 5, 82, 70, 77, 218, 74, 244, 156,
+        ];
+
+        const SETUP_LEAF: Leaf = [
+            168, 152, 44, 137, 216, 9, 135, 251, 154, 81, 14, 37, 152, 30, 233, 23, 2, 6, 190, 33,
+            175, 60, 142, 14, 179, 18, 239, 29, 51, 130, 231, 97,
+        ];
+
+        const SETUP_PROOF: [Node; 2] = [
+            Node {
+                data: [
+                    209, 232, 174, 183, 149, 0, 73, 110, 243, 220, 46, 87, 186, 116, 106, 131, 21,
+                    208, 72, 183, 166, 100, 162, 191, 148, 141, 180, 250, 145, 150, 4, 131,
+                ],
+                side: Side::RIGHT,
+            },
+            Node {
+                data: [
+                    104, 32, 63, 144, 233, 208, 125, 197, 133, 146, 89, 215, 83, 110, 135, 166,
+                    186, 157, 52, 95, 37, 82, 181, 185, 222, 41, 153, 221, 206, 156, 225, 191,
+                ],
+                side: Side::LEFT,
+            },
+        ];
+
+        const WRONG_ROOT: Root = [
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0,
+        ];
+
+        #[test]
+        fn verify_proof_returns_true_for_valid_proof() {
+            let result = MerkleTree::verify_proof(SETUP_PROOF.to_vec(), SETUP_LEAF, SETUP_ROOT);
+            assert!(result);
+        }
+
+        #[test]
+        fn verify_proof_returns_false_for_invalid_root() {
+            let result = MerkleTree::verify_proof(SETUP_PROOF.to_vec(), SETUP_LEAF, WRONG_ROOT);
+            assert!(!result);
+        }
+
+        #[test]
+        fn verify_proof_returns_false_for_wrong_leaf() {
+            let wrong_leaf: Leaf = [0u8; 32];
+            let result = MerkleTree::verify_proof(SETUP_PROOF.to_vec(), wrong_leaf, SETUP_ROOT);
+            assert!(!result);
+        }
+
+        #[test]
+        fn verify_proof_with_hasher_works() {
+            let result = MerkleTree::verify_proof_with_hasher(
+                SETUP_PROOF.to_vec(),
+                SETUP_LEAF,
+                SETUP_ROOT,
+                &Keccak256Hasher,
+            );
+            assert!(result);
         }
     }
 }


### PR DESCRIPTION
Add MerkleTree::verify_proof(proof, leaf, root) -> bool to verify Merkle proofs without needing a tree instance. Also adds verify_proof_with_hasher for custom hasher support.